### PR TITLE
Update ruleset shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,15 @@ The main requirements for a published ruleset are:
   - i.e. must not import any other packages at run time
 - The JS file must include default exports of in the shape of (files should use ES Modules)
   ```javascript
+    import { Ruleset } from '@useoptic/rulesets-base';
     export default {
       name: 'ruleset-name',
-      rules: [] // Any valid rule or ruleset, e.g. SpecificationRule, Ruleset, etc
+      description: 'a description of the ruleset',
+      configSchema: {}, // A JSONSchema object - used to validate the configuration inputs
+      // A function that receives the passed in configuration (defined above)
+      rulesetConstructor: (config: Configuration): Ruleset => {
+        // modify config as necessary
+        return new Ruleset({...});
+      }
     }
     ```

--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ The main requirements for a published ruleset are:
     export default {
       name: 'ruleset-name',
       description: 'a description of the ruleset',
-      configSchema: {}, // A JSONSchema object - used to validate the configuration inputs
+      // A JSONSchema object - used to validate the configuration inputs
+      // Leave this as an empty object if you want to opt out of validating the configuration input
+      configSchema: {},
       // A function that receives the passed in configuration (defined above)
       rulesetConstructor: (config: Configuration): Ruleset => {
         // modify config as necessary

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Matchers, SpecificationRule } from "@useoptic/rulesets-base";
+import { Matchers, Ruleset, SpecificationRule } from "@useoptic/rulesets-base";
 
 export const MustHaveApiVersion = new SpecificationRule({
   name: "Must have api version",
@@ -13,5 +13,21 @@ export const MustHaveApiVersion = new SpecificationRule({
 
 export default {
   name: "example-ruleset",
-  rules: [MustHaveApiVersion],
+  description: "An example ruleset that validates things in OpenAPI",
+  // A JSON schema object
+  configSchema: {
+    type: "object",
+    properties: {
+      required_on: {
+        type: "string",
+        enum: ["always", "added"],
+      },
+    },
+  },
+  rulesetConstructor: (options: { required_on: "always" | "added" }) => {
+    return new Ruleset({
+      name: "example-ruleset",
+      rules: [MustHaveApiVersion],
+    });
+  },
 };


### PR DESCRIPTION
Updates the ruleset shape to accept configSchema and a description. Also updates the constructor to take in a function

Following this, we'll need to update:
- optic cli ruleset publish
- the rule runners
