### PR TITLE
Update custom rules starter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,0 @@
-# Copy + rename this file to `.env`
-# Add your optic token here. Get a token at https://app.useoptic.com
-OPTIC_TOKEN=

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Start by running `npm install` or `yarn install` to install the relevant node_mo
 
 Scripts:
 - `npm run build` - builds and minifies a ruleset package.
-- `npm run publish` - publishes a built ruleset package (from `npm run build`) to optic cloud. Requires an optic token, which is passed in via the `OPTIC_TOKEN` environment variable. See `.env.example` for details.
+- `npm run publish` - publishes a built ruleset package (from `npm run build`) to optic cloud. 
+  > Ensure that you set the `OPTIC_TOKEN` environment variable. You can get a token at https://app.useoptic.com
 - `npm run test` - runs tests
 - `npm run typecheck` - runs typechecking
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Start by running `npm install` or `yarn install` to install the relevant node_mo
 
 Scripts:
 - `npm run build` - builds and minifies a ruleset package.
-- `npm run publish` - publishes a built ruleset package (from `npm run build`) to optic cloud. 
+- `npm run upload` - uploads a built ruleset package (from `npm run build`) to optic cloud. 
   > Ensure that you set the `OPTIC_TOKEN` environment variable. You can get a token at https://app.useoptic.com
 - `npm run test` - runs tests
 - `npm run typecheck` - runs typechecking
@@ -55,14 +55,14 @@ const spec = TestHelpers.createEmptySpec() // returns a base OpenAPI spec
 const results = TestHelpers.runRulesWithInputs(rules, beforeSpec, afterSpec) // runs rules against a before and after spec
 ```
 
-### Building and publishing your rulesets
+### Building and uploading your rulesets
 
-Published rulesets must be bundled into a single file that exports the name of the ruleset and the rules (see [format below](#customizing-your-ruleset-package)).
+Uploaded rulesets must be bundled into a single file that exports the name of the ruleset and the rules (see [format below](#customizing-your-ruleset-package)).
 
-This starter template comes pre-configured with a build and publish step that matches the expected output (see the scripts field in the package.json). To publish your ruleset, follow the steps below:
+This starter template comes pre-configured with a build and upload step that matches the expected output (see the scripts field in the package.json). To upload your ruleset, follow the steps below:
 - run `npm run build` - this will bundle the `src/main.ts` code into a single JS file and output it to `build/main.js`
   - this starter template uses esbuild, but any other bundler could be used (e.g. webpack, parcel, etc)
-- run `npm run publish` - this will publish the bundled rulesets (`build/main.js`) to optic cloud
+- run `npm run upload` - this will upload the bundled rulesets (`build/main.js`) to optic cloud
   - this package will be then available to be used locally and in optic cloud
 
 #### Getting your own token
@@ -71,14 +71,14 @@ A token is required to upload rules to Optic. You can get a token by signing up 
 
 ### Using your rulesets in optic diff and Optic Cloud
 
-Once you have published your ruleset, you can refer to your uploaded ruleset in local runs and optic cloud by it's identifier `@org-slug/ruleset-name` (by default, we identify rulesets in your org). You can specify this ruleset in your `optic.dev.yml` file for optic diff running, and specify which rules to run in Optic cloud in the ruleset page on our [app](https://app.useoptic.com).
+Once you have uploaded your ruleset, you can refer to your uploaded ruleset in local runs and optic cloud by it's identifier `@org-slug/ruleset-name` (by default, we identify rulesets in your org). You can specify this ruleset in your `optic.dev.yml` file for optic diff running, and specify which rules to run in Optic cloud in the ruleset page on our [app](https://app.useoptic.com).
 
 
 ## Customizing your ruleset package
 
 If you want to update the build environment, CI setup, dependencies or any other set up, you can continue to customize from this starter template. 
 
-The main requirements for a published ruleset are:
+The main requirements for a uploaded ruleset are:
 - Must be a single bundled JS file
   - i.e. must not import any other packages at run time
 - The JS file must include default exports of in the shape of (files should use ES Modules)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "optic-custom-rules",
   "version": "1.0.0",
   "scripts": {
-    "publish": "OPTIC_TOKEN=$(grep OPTIC_TOKEN .env | cut -d '=' -f2) optic ruleset publish build/main.js",
+    "publish": "optic ruleset publish build/main.js",
     "build": "esbuild src/main.ts --bundle --main-fields=module,main --platform=node --sourcemap=inline --minify --outfile=build/main.js",
     "test": "jest",
     "typecheck": "tsc"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "name-of-custom-rules-package",
   "version": "1.0.0",
   "scripts": {
-    "upload": "optic ruleset publish build/main.js",
+    "upload": "optic ruleset upload build/main.js",
     "build": "esbuild src/main.ts --bundle --main-fields=module,main --platform=node --sourcemap=inline --minify --outfile=build/main.js",
     "test": "jest",
     "typecheck": "tsc"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "optic-custom-rules",
   "version": "1.0.0",
   "scripts": {
-    "publish": "optic ruleset publish build/main.js",
+    "upload": "optic ruleset publish build/main.js",
     "build": "esbuild src/main.ts --bundle --main-fields=module,main --platform=node --sourcemap=inline --minify --outfile=build/main.js",
     "test": "jest",
     "typecheck": "tsc"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "optic-custom-rules",
+  "name": "name-of-custom-rules-package",
   "version": "1.0.0",
   "scripts": {
     "upload": "optic ruleset publish build/main.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ export const MustHaveApiVersion = new SpecificationRule({
 });
 
 export default {
-  name: "example-ruleset",
+  name: "name-of-custom-rules-package",
   description: "An example ruleset that validates things in OpenAPI",
   // A JSON schema object
   configSchema: {
@@ -26,7 +26,7 @@ export default {
   },
   rulesetConstructor: (options: { required_on: "always" | "added" }) => {
     return new Ruleset({
-      name: "example-ruleset",
+      name: "name-of-custom-rules-package",
       rules: [MustHaveApiVersion],
     });
   },


### PR DESCRIPTION
Updates the following things:
- removes `.env` flow - since your likely going to run this in CI (less likely you publish this adhoc unless your testing), simplifies the starter template so you can go whatever way you'd like
- renames publish -> upload. running `npm publish` will run the publish flow to npm (and also run the script name :)) - changing the script name to upload reduces the chance of this happening
- add placeholder text for init so we can inject the ruleset name from `optic ruleset init`