### PR TITLE
Resolve promises before testing

### DIFF
--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -3,7 +3,7 @@ import { MustHaveOperationDescription } from "../main";
 import { TestHelpers } from "@useoptic/rulesets-base";
 import { OpenAPIV3 } from "@useoptic/openapi-utilities";
 
-test("MustHaveOperationDescription", () => {
+test("MustHaveOperationDescription", async () => {
   const beforeApiSpec: OpenAPIV3.Document = {
     ...TestHelpers.createEmptySpec(),
   };
@@ -34,7 +34,7 @@ test("MustHaveOperationDescription", () => {
       }
     }
   };
-  const ruleResults = TestHelpers.runRulesWithInputs(
+  const ruleResults = await TestHelpers.runRulesWithInputs(
     [MustHaveOperationDescription],
     beforeApiSpec,
     afterApiSpec


### PR DESCRIPTION
Hello, Optic folks!

I ran the test suite in the default ruleset created by the `optic ruleset init` command and got a couple of TS errors:

```
$ npm run test

> optic-ruleset@1.0.0 test
> jest

 FAIL  src/__tests__/main.test.ts
  ● Test suite failed to run

    src/__tests__/main.test.ts:43:22 - error TS2339: Property 'length' does not exist on type 'Promise<Result[]>'.

    43   expect(ruleResults.length > 0).toBe(true);
                            ~~~~~~

      src/__tests__/main.test.ts:43:22
        43   expect(ruleResults.length > 0).toBe(true);
                                ~~~~~~
        Did you forget to use 'await'?
    src/__tests__/main.test.ts:44:22 - error TS2339: Property 'every' does not exist on type 'Promise<Result[]>'.

    44   expect(ruleResults.every((result) => result.passed)).toBe(true);
                            ~~~~~

      src/__tests__/main.test.ts:44:22
        44   expect(ruleResults.every((result) => result.passed)).toBe(true);
                                ~~~~~
        Did you forget to use 'await'?

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        1.244 s
Ran all test suites.
```

This change resolves the `Promise<Result[]>` from the rule execution into a `Result[]` so code can run assertions on the results. It also ignores the `package-lock.json` file. 

Thanks for your time checking this out!